### PR TITLE
Add developer dialog to edit payment request

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -19,7 +19,9 @@
     "iron-pages": "polymerelements/iron-pages#^2.0.0",
     "iron-selector": "polymerelements/iron-selector#^2.0.0",
     "paper-icon-button": "polymerelements/paper-icon-button#^2.0.0",
-    "paper-spinner": "polymerelements/paper-spinner#^2.0.0"
+    "paper-spinner": "polymerelements/paper-spinner#^2.0.0",
+    "paper-dialog": "^2.1.1",
+    "ace-widget": "LostInBrittany/ace-widget#^1.3.7"
   },
   "devDependencies": {
     "web-component-tester": "^6.0.0"

--- a/src/shop-app.html
+++ b/src/shop-app.html
@@ -19,6 +19,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="../bower_components/iron-pages/iron-pages.html">
 <link rel="import" href="../bower_components/iron-meta/iron-meta.html">
 <link rel="import" href="../bower_components/iron-selector/iron-selector.html">
+<link rel="import" href="shop-developer.html">
 <link rel="import" href="shop-category-data.html">
 <link rel="import" href="shop-payment-request.html">
 <link rel="import" href="shop-payment-method.html">
@@ -243,6 +244,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <iron-media-query query="max-width: 767px" query-matches="{{smallScreen}}"></iron-media-query>
     <iron-meta id="meta" type="account"></iron-meta>
 
+    <shop-developer id="developerDialog"></shop-developer>
+
     <!--
       shop-category-data provides the list of categories.
     -->
@@ -311,7 +314,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             <paper-icon-button icon="arrow-back" aria-label="Go back"></paper-icon-button>
           </a>
         </div>
-        <div class="left-bar-item"></div>
+        <div class="left-bar-item">
+          <a on-tap="_openDeveloperDialog">
+            <paper-icon-button
+              aria-label="Developer"></paper-icon-button>
+          </a>
+        </div>
         <div class="logo" main-title><a href="/" aria-label="SHOP Home">SHOP</a></div>
         <div class="account-btn-container">
           <a href="/account" tabindex="-1">
@@ -464,6 +472,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         this.addEventListener('buy-google', (e)=>this._onBuyGoogle(e));
         this.addEventListener('process-payment', (e)=>this._processPayment(e));
         this.addEventListener('logout', (e)=>this._onLogout(e));
+        this.addEventListener('load-payment-data', (e)=>this._onLoadPaymentData(e));
         // listen for online/offline
         Polymer.RenderStatus.afterNextRender(this, () => {
           window.addEventListener('online', (e)=>this._notifyNetworkStatus(e));
@@ -858,6 +867,23 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         } else {
           return 'account-circle';
         }
+      }
+
+      _openDeveloperDialog() {
+        let displayItems = this._getDisplayItemsFromCart();
+        let data = this.payment.getGPayData(displayItems);
+        this.$.developerDialog.setEditorValue(data);
+        this.$.developerDialog.open();
+      }
+
+      _onLoadPaymentData() {
+        this.payment.loadPaymentData(this.$.developerDialog.getEditorValue())
+        .then(instrument => {
+          this.$.developerDialog.setResponseValue(instrument);
+        })
+        .catch(err => {
+          this.$.developerDialog.setResponseValue(err);
+        });
       }
     }
 

--- a/src/shop-developer.html
+++ b/src/shop-developer.html
@@ -1,0 +1,114 @@
+<!--
+@license
+Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+
+<link rel="import" href="../bower_components/polymer/polymer.html">
+<link rel="import" href="../bower_components/paper-dialog/paper-dialog.html">
+<link rel="import" href="../bower_components/ace-widget/ace-widget.html">
+<link rel="import" href="shop-button.html">
+<link rel="import" href="shop-checkout.html">
+<link rel="import" href="shop-common-styles.html">
+
+<dom-module id="shop-developer">
+
+  <template>
+
+    <style include="shop-common-styles shop-button shop-checkout">
+
+      @media (max-width: 600px) {
+        paper-dialog {
+          position: absolute;
+          top: 0;
+          right: 0;
+          bottom: 0;
+          left: 0;
+          margin: 0;
+        }
+      }
+
+      @media (min-width: 601px) {
+        paper-dialog {
+            width: calc(100% - 20px);
+            max-width: 1000px;
+            height: calc(100% - 20px);
+            max-height: 1000px;
+        }
+      }
+
+      #buttonRow {
+        justify-content: center;
+        margin: 10px;
+      }
+
+    </style>
+
+    <paper-dialog id="dialog">
+      <div>
+        <h2>Developer Console</h2>
+        <ace-widget
+          id="aceWidget"
+          mode="ace/mode/json"
+          theme="ace/theme/monokai"
+          initialFocus></ace-widget>
+        <div class="row" id="buttonRow">
+          <button
+            class="googlepay"
+            on-tap="_loadPaymentData"
+            title="Buy with Google Pay"></button>
+        </div>
+        <div id="response">
+          <h3>Response</h3>
+          <ace-widget
+            id="aceWidgetResponse"
+            mode="ace/mode/json"
+            theme="ace/theme/solarized_light"
+            readonly
+            maxLines=10></ace-widget>
+        </div>
+      </div>
+    </paper-dialog>
+
+  </template>
+
+  <script>
+
+    class ShopDeveloper extends Polymer.Element {
+
+      static get is() { return 'shop-developer'; }
+
+      open() {
+        this.$.aceWidgetResponse.editor.renderer.setShowGutter(false);
+        this.$.dialog.open();
+      }
+
+      getEditorValue() {
+        return JSON.parse(this.$.aceWidget.editor.getValue());
+      }
+
+      setEditorValue(obj) {
+        this.$.aceWidget.editor.setValue(JSON.stringify(obj, null, '\t'));
+      }
+
+      setResponseValue(obj) {
+        this.$.aceWidgetResponse.editor.setValue(JSON.stringify(obj, null, '\t'));
+      }
+
+      _loadPaymentData() {
+        this.dispatchEvent(new CustomEvent('load-payment-data', {
+          bubbles: true, composed: true
+        }));
+      }
+
+    }
+
+    customElements.define(ShopDeveloper.is, ShopDeveloper);
+
+  </script>
+
+</dom-module>

--- a/src/shop-payment-request.html
+++ b/src/shop-payment-request.html
@@ -188,6 +188,20 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         return this.gPayClient.loadPaymentData(this.gPayData);
       }
 
+      loadPaymentData(data) {
+        return this.gPayClient.loadPaymentData(data);
+      }
+
+      getGPayData(displayItems) {
+        let total = this._getToalFromDisplayItems(displayItems);
+        this.gPayData.transactionInfo = {
+          totalPriceStatus: 'FINAL',
+          totalPrice: parseFloat(total.amount.value),
+          currencyCode: this.currency
+        };
+        return this.gPayData;
+      }
+
       _updateShippingAddress(details, addr, resolve) {
         // If there's no shipping options for the address, it will be rejected on an empty array
         details.shippingOptions = [];


### PR DESCRIPTION
This creates a developer console of sorts that allows you to edit the current payment request (from the checkout cart) and continue the flow by clicking the "Buy with Google Pay" button.

The dialog is opened by clicking a blank link on the top left area of the header:
![image](https://user-images.githubusercontent.com/6180974/38842733-7760bd1c-41a0-11e8-8bc4-eec7c58204b3.png)

What the dialog looks like:
![image](https://user-images.githubusercontent.com/6180974/38842784-a658955e-41a0-11e8-81d1-b989561c0e98.png)
